### PR TITLE
Use Kubernetes v1.11

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,7 +2,9 @@
 
 This repository contains playbooks to deploy a GCS cluster on Kubernetes. It also contains a Vagrantfile to setup a local GCS cluster using vagrant-libvirt.
 
-> IMP: Clone this repository with submodules
+> _NOTE: The deployment works for Kubernetes 1.11 for now. Kubernetes 1.12 introduces new changes for CSI drivers, which are yet to be implemented._
+
+> _IMP: Clone this repository with submodules_
 
 ## Available playbooks
 

--- a/deploy/deploy-k8s.yml
+++ b/deploy/deploy-k8s.yml
@@ -5,5 +5,6 @@
     dns_mode: "coredns"
     docker_mount_flags: "shared"
     kube_network_plugin: "flannel"
+    kube_version: "v1.11.3"
     kubeconfig_localhost: true
     local_volumes_enabled: true


### PR DESCRIPTION
Kubernetes v1.12 brings in a few changes with respect to CSI drivers
particularly with permissions and the method of driver registration, and
requires changes to the CSI driver deployment to get it to work.

With v1.12, the CSI provisioner works well and creates volumes for PVCs
with glusterfs-csi storage class, but the CSI nodeplugin is not able to
mount volumes as the driver registration isn't done correctly.

TODO: Open a issue to track changes needed for v1.12