### PR TITLE
add gluster as pod name prefix

### DIFF
--- a/deploy/tasks/add-devices-to-peer.yml
+++ b/deploy/tasks/add-devices-to-peer.yml
@@ -2,7 +2,7 @@
 ---
 - name: GCS | GD2 Cluster | Add devices | Set facts
   set_fact:
-    kube_hostname: "{{ peer.name.split('-')[0]}}"
+    kube_hostname: "{{ peer.name.split('-')[1]}}"
 
 - name: GCS | GD2 Cluster | Add devices | Add devices for {{ kube_hostname }}
   uri:

--- a/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
@@ -2,7 +2,7 @@
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: {{ kube_hostname }}
+  name: gluster-{{ kube_hostname }}
   namespace: {{ gcs_namespace }}
   labels:
     app.kubernetes.io/part-of: gcs
@@ -46,9 +46,9 @@ spec:
             - name: GD2_CLUSTER_ID
               value: "{{ gcs_gd2_clusterid }}"
             - name: GD2_CLIENTADDRESS
-              value: "{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24007"
+              value: "gluster-{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24007"
             - name: GD2_PEERADDRESS
-              value: "{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24008"
+              value: "gluster-{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24008"
             # TODO: Remove RESTAUTH false once we enable setting auth token
             # using secrets
             - name: GD2_RESTAUTH


### PR DESCRIPTION
Fixes: #18 
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

output:
```
[vagrant@kube1 ~]$ kubectl get po -n gcs
NAME                                   READY   STATUS    RESTARTS   AGE
csi-attacher-glusterfsplugin-0         2/2     Running   0          28m
csi-nodeplugin-glusterfsplugin-99m5w   2/2     Running   0          28m
csi-nodeplugin-glusterfsplugin-jm768   2/2     Running   0          28m
csi-nodeplugin-glusterfsplugin-x9m5m   2/2     Running   0          28m
csi-provisioner-glusterfsplugin-0      2/2     Running   0          28m
etcd-5ntqcq5587                        1/1     Running   0          30m
etcd-nffhbtvq6h                        1/1     Running   0          31m
etcd-operator-7cb5bd459b-jnfv7         1/1     Running   0          32m
etcd-xrntbxh5xz                        1/1     Running   0          32m
gluster-kube1-0                        1/1     Running   0          30m
gluster-kube2-0                        1/1     Running   0          30m
gluster-kube3-0                        1/1     Running   0          30m

```