### PR TITLE
update kubernetes version to v1.12.1

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,8 +2,6 @@
 
 This repository contains playbooks to deploy a GCS cluster on Kubernetes. It also contains a Vagrantfile to setup a local GCS cluster using vagrant-libvirt.
 
-> _NOTE: The deployment works for Kubernetes 1.11 for now. Kubernetes 1.12 introduces new changes for CSI drivers, which are yet to be implemented._
-
 > _IMP: Clone this repository with submodules_
 
 ## Available playbooks

--- a/deploy/deploy-k8s.yml
+++ b/deploy/deploy-k8s.yml
@@ -5,6 +5,6 @@
     dns_mode: "coredns"
     docker_mount_flags: "shared"
     kube_network_plugin: "flannel"
-    kube_version: "v1.11.3"
+    kube_version: "v1.12.1"
     kubeconfig_localhost: true
     local_volumes_enabled: true

--- a/deploy/templates/gcs-manifests/gcs-csi.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-csi.yml.j2
@@ -164,9 +164,12 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           env:
             - name: ADDRESS
               value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/org.gluster.glusterfs/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -174,6 +177,8 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
         - name: gluster-nodeplugin
           securityContext:
             privileged: true
@@ -208,6 +213,10 @@ spec:
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet/pods
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
             type: Directory
 
 ## Deploy GCS CSI Provisioner


### PR DESCRIPTION
updated node plugin template which is required for kubernetes v1.12.1.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

output
## kubectl version
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.1", GitCommit:"4ed3216f3ec431b140b1d899130a69fc671678f4", GitTreeState:"clean", BuildDate:"2018-10-05T16:36:14Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.1", GitCommit:"4ed3216f3ec431b140b1d899130a69fc671678f4", GitTreeState:"clean", BuildDate:"2018-10-05T16:36:14Z", GoVersion:"go1.10.4", Compiler:"gc", Platform:"linux/amd64"}
```
## pod status

```
[vagrant@kube1 ~]$ kubectl get po
NAME          READY   STATUS    RESTARTS   AGE
gcs-example   1/1     Running   0          45s
```

```
[vagrant@kube1 ~]$ kubectl describe po/gcs-example
Name:               gcs-example
Namespace:          default
Priority:           0
PriorityClassName:  <none>
Node:               kube2/192.168.121.31
Start Time:         Thu, 11 Oct 2018 13:22:28 +0000
Labels:             app=redis
Annotations:        <none>
Status:             Pending
IP:                 
Containers:
  redis:
    Container ID:   
    Image:          redis:latest
    Image ID:       
    Port:           <none>
    Host Port:      <none>
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /data from gcs-example-volume (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-v8znv (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  gcs-example-volume:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  gcs-example-volume
    ReadOnly:   false
  default-token-v8znv:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-v8znv
    Optional:    false
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Warning  FailedScheduling        19s (x9 over 36s)  default-scheduler        pod has unbound immediate PersistentVolumeClaims (repeated 3 times)
  Normal   Scheduled               19s                default-scheduler        Successfully assigned default/gcs-example to kube2
  Normal   SuccessfulAttachVolume  18s                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-a98c0de4cd5811e8"
  Normal   Pulling                 6s                 kubelet, kube2           pulling image "redis:latest"
```


mount info
```
kube1-0.glusterd2.gcs:pvc-a98c0de4cd5811e8 on /var/lib/kubelet/pods/a99009af-cd58-11e8-a385-52540065898d/volumes/kubernetes.io~csi/pvc-a98c0de4cd5811e8/mount type fuse.glusterfs (rw,relatime,user_id=0,group_id=0,default_permissions,allow_other,max_read=131072)
```