### PR TITLE
New env variable added `GD2_ENDPOINTS`

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
@@ -47,6 +47,8 @@ spec:
               value: "{{ gcs_gd2_clusterid }}"
             - name: GD2_CLIENTADDRESS
               value: "gluster-{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24007"
+            - name: GD2_ENDPOINTS
+              value: "http://gluster-{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24007"
             - name: GD2_PEERADDRESS
               value: "gluster-{{ kube_hostname }}-0.glusterd2.{{ gcs_namespace }}:24008"
             # TODO: Remove RESTAUTH false once we enable setting auth token


### PR DESCRIPTION
Glusterd2 CLI enhanced to get list of endpoints from environment
variable `GD2_ENDPOINTS` with PR https://github.com/gluster/glusterd2/pull/1292

With this env variable `glustercli` can get the details of running glusterd2
endpoint(s) to make REST API calls.

Signed-off-by: Aravinda VK <avishwan@redhat.com>