### PR TITLE
Update gd2 container image to fix size issue

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
@@ -33,7 +33,7 @@ spec:
                     - {{ kube_hostname }}
       containers:
         - name: glusterd2
-          image: docker.io/gluster/glusterd2-nightly:20180920
+          image: docker.io/gluster/glusterd2-nightly
           livenessProbe:
             httpGet:
               path: /ping


### PR DESCRIPTION
volume size
```
root@gcs-example:/data# df -h /data
Filesystem                                                              Size  Used Avail Use% Mounted on
gluster-kube1-0.glusterd2.gcs:pvc-64c5e59e-d83d-11e8-833c-5254001fb83f 1014M   43M  972M   5% /data

```

Rest response
```
curl http://gluster-kube1-0.glusterd2.gcs:24007/v1/volumes/pvc-64c5e59e-d83d-11e8-833c-5254001fb83f/status |python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1580  100  1580    0     0   9272      0 --:--:-- --:--:-- --:--:--  9294
{
    "info": {
        "distribute-count": 1,
        "id": "0d2c6927-b42f-488a-a1f1-8ebb59b97f1f",
        "metadata": {
            "VolumeOwner": "org.gluster.glusterfs"
        },
        "name": "pvc-64c5e59e-d83d-11e8-833c-5254001fb83f",
        "options": {},
        "replica-count": 3,
        "snap-list": [],
        "state": "Started",
        "subvols": [
            {
                "arbiter-count": 0,
                "bricks": [
                    {
                        "host": "gluster-kube1-0.glusterd2.gcs",
                        "id": "58b07abc-eaa8-44c4-b3d7-012242765a97",
                        "path": "/var/run/glusterd2/bricks/pvc-64c5e59e-d83d-11e8-833c-5254001fb83f/subvol1/brick1/brick",
                        "peer-id": "0d59a021-234b-457e-8710-d24bb6c5c439",
                        "type": "Brick",
                        "volume-id": "0d2c6927-b42f-488a-a1f1-8ebb59b97f1f",
                        "volume-name": "pvc-64c5e59e-d83d-11e8-833c-5254001fb83f"
                    },
                    {
                        "host": "gluster-kube3-0.glusterd2.gcs",
                        "id": "41af2976-69a8-4569-967d-88f003ba605d",
                        "path": "/var/run/glusterd2/bricks/pvc-64c5e59e-d83d-11e8-833c-5254001fb83f/subvol1/brick2/brick",
                        "peer-id": "33f735d1-5199-42e1-8d69-b3c814cc8711",
                        "type": "Brick",
                        "volume-id": "0d2c6927-b42f-488a-a1f1-8ebb59b97f1f",
                        "volume-name": "pvc-64c5e59e-d83d-11e8-833c-5254001fb83f"
                    },
                    {
                        "host": "gluster-kube2-0.glusterd2.gcs",
                        "id": "3501f52d-40f1-485f-ba2e-ca959bc22539",
                        "path": "/var/run/glusterd2/bricks/pvc-64c5e59e-d83d-11e8-833c-5254001fb83f/subvol1/brick3/brick",
                        "peer-id": "5515b4e9-1f1b-4776-a412-82e7a17aa711",
                        "type": "Brick",
                        "volume-id": "0d2c6927-b42f-488a-a1f1-8ebb59b97f1f",
                        "volume-name": "pvc-64c5e59e-d83d-11e8-833c-5254001fb83f"
                    }
                ],
                "disperse-count": 0,
                "name": "pvc-64c5e59e-d83d-11e8-833c-5254001fb83f-replicate-0",
                "replica-count": 3,
                "type": "Replicate"
            }
        ],
        "transport": "tcp",
        "type": "Replicate"
    },
    "online": true,
    "size": {
        "capacity": 1063256064,
        "free": 1018527744,
        "used": 44728320
    }
}

```
Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>