### PR TITLE
GCS-Prometheus Integration

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
+  config.vm.network "forwarded_port", guest: 30600, host: 9090, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 30800, host: 9000, host_ip: "127.0.0.1"
 
   config.vm.box = "centos/atomic-host"
   host_vars = {}

--- a/deploy/deploy-gcs.yml
+++ b/deploy/deploy-gcs.yml
@@ -39,6 +39,11 @@
             - gcs-etcd-cluster.yml
             - gcs-gd2-services.yml
             - gcs-csi.yml
+            - monitoring-namespace.yml
+            - gcs-prometheus-operator.yml
+            - gcs-prometheus-bundle.yml
+            - gcs-prometheus-alertmanager-cluster.yml
+            - gcs-grafana.yml
 
         - name: GCS Pre | Manifests | Create GD2 manifests
           include_tasks: tasks/create-gd2-manifests.yml
@@ -57,6 +62,11 @@
       kube:
         kubectl: "{{ kubectl }}"
         file: "{{ manifests_dir }}/gcs-namespace.yml"
+
+    - name: GCS | Namespace | Create Monitoring namespace
+      kube:
+        kubectl: "{{ kubectl }}"
+        file: "{{ manifests_dir }}/monitoring-namespace.yml"
 
     - name: GCS | ETCD Operator
       block:
@@ -174,3 +184,32 @@
           until: result.stdout|int == 3
           delay: 10
           retries: 50
+
+    - name: GCS | Prometheus Operator
+      block:
+        - name: GCS | Prometheus Operator | Deploy Prometheus Operator
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-operator.yml"
+
+        - name: GCS | Prometheus Operator | Wait for the Prometheus Operator to become ready
+          command: "{{ kubectl }} -n{{ monitoring_namespace }} -ojsonpath='{.status.availableReplicas}' get deployment prometheus-operator"
+          register: result
+          until: result.stdout|int == 1
+          delay: 10
+          retries: 50
+
+    - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Object
+      kube:
+        kubectl: "{{ kubectl }}"
+        file: "{{ manifests_dir }}/gcs-prometheus-bundle.yml"
+
+    - name: GCS | Alertmanager Cluster
+      kube:
+        kubectl: "{{ kubectl }}"
+        file: "{{ manifests_dir }}/gcs-prometheus-alertmanager-cluster.yml"
+
+    - name: GCS | Grafana Dashboard | Deploy Grafana Dashboard
+      kube:
+        kubectl: "{{ kubectl }}"
+        file: "{{ manifests_dir }}/gcs-grafana.yml"

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -1,1 +1,2 @@
 gcs_namespace: "gcs"
+monitoring_namespace: "monitoring"

--- a/deploy/templates/gcs-manifests/gcs-gd2-services.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-gd2-services.yml.j2
@@ -46,6 +46,8 @@ spec:
       protocol: TCP
       port: 24007
       targetPort: 24007
+    - name: metrics
+      port: 8080
 
 ---
 # Nodeport service for access to GD2 from outside the cluster

--- a/deploy/templates/gcs-manifests/gcs-grafana.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-grafana.yml.j2
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data
+  labels:
+    name: data
+  namespace: monitoring
+data:
+  config: |-
+
+    apiVersion: 1
+
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      url: http://localhost:9090
+      access: direct
+      basicAuth: false
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:5.3.2
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2500Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: data
+          readOnly: false
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: data
+          configMap:
+             name: data
+             items:
+              - key: config
+                path: datasource.yml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    nodePort: 30800
+    port: 80
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: grafana

--- a/deploy/templates/gcs-manifests/gcs-prometheus-alertmanager-cluster.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-alertmanager-cluster.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: alert
+  namespace: {{ monitoring_namespace }}
+spec:
+  replicas: 3

--- a/deploy/templates/gcs-manifests/gcs-prometheus-bundle.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-bundle.yml.j2
@@ -1,0 +1,95 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gluster-prometheus
+  namespace: {{ monitoring_namespace }}
+  labels:
+    team: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: gcs
+      app.kubernetes.io/component: glusterfs
+      app.kubernetes.io/name: glusterd2-service
+  namespaceSelector:
+    matchNames: 
+      - {{ gcs_namespace }}
+  endpoints:
+  - port: metrics
+    targetPort: 8080
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: {{ monitoring_namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: {{ monitoring_namespace }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  namespace: {{ monitoring_namespace }}
+spec:
+  replicas: 2
+  serviceAccountName: prometheus
+  scrapeInterval: 5s
+  alerting:
+    alertmanagers:
+    - namespace: {{ monitoring_namespace }}
+      name: alertmanager-alert
+      port: metrics
+  serviceMonitorSelector:
+    matchLabels:
+      team: monitoring
+  ruleSelector:
+    matchLabels:
+      role: alert-rules
+      prometheus: alert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: {{ monitoring_namespace }}
+spec:
+  type: NodePort
+  ports:
+  - name: metrics
+    nodePort: 30600
+    port: 9090
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    prometheus: prometheus

--- a/deploy/templates/gcs-manifests/gcs-prometheus-operator.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-operator.yml.j2
@@ -1,0 +1,130 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: {{ monitoring_namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheuses/finalizers
+  - alertmanagers/finalizers
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: prometheus-operator
+  name: prometheus-operator
+  namespace: {{ monitoring_namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: prometheus-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: prometheus-operator
+    spec:
+      containers:
+      - args:
+        - --kubelet-service=kube-system/kubelet
+        - --logtostderr=true
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.25.0
+        image: quay.io/coreos/prometheus-operator:v0.25.0
+        name: prometheus-operator
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: prometheus-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-operator
+  namespace: {{ monitoring_namespace }}

--- a/deploy/templates/gcs-manifests/monitoring-namespace.yml.j2
+++ b/deploy/templates/gcs-manifests/monitoring-namespace.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ monitoring_namespace }}


### PR DESCRIPTION
Connects to gluster/gluster-prometheus#45 . This PR integrates Prometheus deployment with the GCS setup. Prometheus is a monitoring system used for scraping metrics that are exposed from exporters. With the PR [gluster/glusterd2#1308](https://github.com/gluster/glusterd2/pull/1308/), gluster-prometheus exporter will be containerized along with glusterd2. 

Since monitoring systems are not stateless i.e stateful, they are difficult to set up in a kubernetes environment. The workaround is the prometheus operator. The operator takes care of deploying and managing the prometheus server and also managing a set of Custom Resource Definition (CRD) objects called ServiceMonitor, Prometheus, Alertmanager, PrometheusRule. To learn more about these CRDs, refer https://github.com/coreos/prometheus-operator/blob/master/Documentation/design.md.

The added deployment files and changes to the existing gcs code are:

1. Created a new ```monitoring```  namespace. The prometheus operator and the CRD objects are defined using this namespace.
2. Prometheus operator deployment( ```templates/gcs-manifests/gcs-prometheus-operator.yml.j2``` )
3. Prometheus CRD deployments: This includes a ```service``` that select gd2 pods using the label selector ```app.kubernetes.io/name: glusterd2``` and expose metrics on local port 8080 , a ```ServiceMonitor``` object that selects the service and exposes the metrics to a ```Prometheus``` object. Recording rules and Alerting rules defined on the ```PrometheusRule``` object ( ```PrometheusRule``` not included in this PR. Alerting Rules have to be specified by the user. Will update on how to add alerting rules to the working GCS-Prometheus deployment ) are loaded onto the ```Prometheus``` object. A service to expose the metrics and alerts outside the cluster using ```NodePort```. The metrics can be accessed at port 30600. Also includes an ```Alertmanager``` cluster which has to be configured by the user by mounting a ```secret``` created by a configuration file alertmanager.yaml which contains the configuration for where to send the alerts to. For example, slack or email. Refer https://prometheus.io/docs/alerting/configuration/ for more info on defining this configuration file. Refer https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md on creating secret from alertmanager.yaml. The CRD objects are defined in ```templates/gcs-manifests/gcs-prometheus-bundle.yml.j2``` and the Alertmanagers in ```templates/gcs-manifests/gcs-prometheus-alertmanager-cluster.yml.j2```