### PR TITLE
update Readme to access gluster-cli

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -173,17 +173,10 @@ gluster-kube3-0   1/1     Running   0          16h
 [root@gluster-kube1-0 /]#
 ```
 
-* Get Endpoint to access glusterd2 from glustercli
-
-```
-[root@gluster-kube1-0 /]# printenv |grep GD2_CLIENTADDRESS |cut -d'=' -f2
-gluster-kube1-0.glusterd2.gcs:24007
-```
-
 - Accessing glustercli inside pod
 
 ```
-[root@gluster-kube1-0 /]# glustercli peer  list --endpoints=http://gluster-kube1-0.glusterd2.gcs:24007
+[root@gluster-kube1-0 /]# glustercli peer  list
 +--------------------------------------+---------+-----------------------------+-----------------------------+--------+-----+
 |                  ID                  |  NAME   |      CLIENT ADDRESSES       |       PEER ADDRESSES        | ONLINE | PID |
 +--------------------------------------+---------+-----------------------------+-----------------------------+--------+-----+


### PR DESCRIPTION
In PR #43 support for `GD2_ENDPOINTS` env variable has been added. we don't
need to pass `--endpoints` option to the glustercli to talk to glusterd2.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>