### PR TITLE
Add retries to deployment

### DIFF
--- a/deploy/deploy-gcs.yml
+++ b/deploy/deploy-gcs.yml
@@ -141,15 +141,10 @@
         - name: GCS | GD2 Cluster | Wait for glusterd2-cluster to become ready
           uri:
             url: "{{ gd2_client_endpoint }}/v1/peers"
-          register: result
-          until: result.status is defined and (result.status == 200 and result.json|length == groups['kube-node']|length)
+          register: peers_resp
+          until: peers_resp.status is defined and (peers_resp.status == 200 and peers_resp.json|length == groups['kube-node']|length)
           delay: 10
           retries: 50
-
-        - name: GCS | GD2 Cluster | Get peers in cluster
-          uri:
-            url: "{{ gd2_client_endpoint }}/v1/peers"
-          register: peers_resp
 
         - name: GCS | GD2 Cluster | Add devices
           include_tasks: ./tasks/add-devices-to-peer.yml

--- a/deploy/tasks/add-devices-to-peer.yml
+++ b/deploy/tasks/add-devices-to-peer.yml
@@ -10,6 +10,10 @@
     method: POST
     body: "{ \"device\": \"{{ disk }}\"}"
     body_format: json
+  register: res
+  until: res.status is defined and res.status == 200
+  delay: 10
+  retries: 50
   loop: "{{ hostvars[kube_hostname].gcs_disks }}"
   loop_control:
     loop_var: disk


### PR DESCRIPTION
Deployment tended to fail at 2 points:
- When getting the gd2 peers
- When adding devices

It appears that these two failure points can be avoided by adding
retries. This commit adds those retries. We retry getting peers by just
removing the (repeat) fetch of the peers as the first instance had
retries already. When adding devices, we simply try again if necessary
during the loop.

The fixes (particularly the second) are not ideal as I don't think we
have a full understanding of the nature of the transient failures.

-----

I believe this will help #44  and #38, but I'm not closing them since it's unclear that this is the proper fix, particularly the retry during device add.