### PR TITLE
Switch to auto-built gluster CSI containers

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-csi.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-csi.yml.j2
@@ -75,7 +75,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: glusterfs
-          image: docker.io/gluster/glusterfs-csi-driver
+          image: docker.io/gluster/gluster-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -185,7 +185,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/gluster/glusterfs-csi-driver
+          image: docker.io/gluster/gluster-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -300,7 +300,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: gluster-provisioner
-          image: docker.io/gluster/glusterfs-csi-driver
+          image: docker.io/gluster/gluster-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"


### PR DESCRIPTION
This changes the container image used for the gluster CSI drivers. The
new image path points to the image that is automatically built when
commits are added to the gluster-csi-driver repo. The old image repo
relied on manual pushes and tended to be out of date.

**Note:** "latest" refers to current master branch