### PR TITLE
Install socat on hosts

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,1 @@
+kubeconfig

--- a/deploy/deploy-k8s.yml
+++ b/deploy/deploy-k8s.yml
@@ -1,4 +1,24 @@
 ---
+- name: Install extra packages
+  hosts: all
+  become: true
+  tasks:
+
+  - name: Install packages
+    command: "rpm-ostree install {{ item }}"
+    with_items:
+      # socat is needed for Helm
+      - socat
+
+  - name: Reboot to make layered packages available
+    shell: sleep 2 && systemctl reboot
+    async: 1
+    poll: 0
+
+  - name: Wait for host to be available
+    wait_for_connection:
+      delay: 15
+
 - name: Deploy K8S
   import_playbook: "kubespray/cluster.yml"
   vars:
@@ -9,3 +29,13 @@
     kubeconfig_localhost: true
     local_volumes_enabled: true
     kube_feature_gates: ["VolumeSnapshotDataSource=true","CSINodeInfo=true","CSIDriverRegistry=true"]
+
+- name: Fetch config
+  hosts: kube-master[0]
+  become: true
+  tasks:
+    - name: Retrieve kubectl config
+      fetch:
+        dest: ./kubeconfig
+        flat: yes
+        src: /root/.kube/config


### PR DESCRIPTION
The lack of `socat` was preventing Helm from running in the GCS Vagrant
environment. This patch installs socat on the atomic hosts. It also
fetches the kubectl config into the local directory once installation is
complete, making it possible to use kubectl on the local machine to
access the cluster:
`$ kubectl --kubeconfig=kubeconfig get nodes`

Related to #14 