### PR TITLE
Fix Prometheus CRD deployment issue and changed VagrantFile to forward port from one Node

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -7,15 +7,15 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
-  config.vm.network "forwarded_port", guest: 30600, host: 9090, host_ip: "127.0.0.1"
-  config.vm.network "forwarded_port", guest: 30800, host: 9000, host_ip: "127.0.0.1"
-
   config.vm.box = "centos/atomic-host"
   host_vars = {}
   (1..3).each do |i|
     config.vm.define vm_name = "kube#{i}" do |vm|
       vm.vm.hostname = vm_name
-
+      if i == 1
+        config.vm.network "forwarded_port", guest: 30600, host: 9090, host_ip: "127.0.0.1"
+        config.vm.network "forwarded_port", guest: 30800, host: 9000, host_ip: "127.0.0.1"
+      end
       vm.vm.provider :libvirt do |lv|
         lv.default_prefix = "gcs"
         lv.cpus = 2

--- a/deploy/deploy-gcs.yml
+++ b/deploy/deploy-gcs.yml
@@ -199,10 +199,33 @@
           delay: 10
           retries: 50
 
-    - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Object
-      kube:
-        kubectl: "{{ kubectl }}"
-        file: "{{ manifests_dir }}/gcs-prometheus-bundle.yml"
+    - name: GCS | Prometheus Objects 
+      block:
+        - name: Check if the Custrom Resource Definitions are set
+          command: "{{ kubectl }} get customresourcedefinitions servicemonitors.monitoring.coreos.com"
+          register: result
+          until: result.rc == 0
+          delay: 10
+          retries: 30
+
+        - name: Check if Service Monitor CRD is registered
+          command: "{{ kubectl }} get servicemonitors -n{{ monitoring_namespace }}"
+          register: result
+          until: result.rc == 0
+          delay: 10
+          retries: 30
+
+        - name: Check if Prometheus CRD object is registered
+          command: "{{ kubectl }} get Prometheus -n{{ monitoring_namespace }}"
+          register: result
+          until: result.rc == 0
+          delay: 10
+          retries: 30
+
+        - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Objects 
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-bundle.yml"
 
     - name: GCS | Alertmanager Cluster
       kube:


### PR DESCRIPTION
The Prometheus objects deployment fails sometimes because there is a race in Kubernetes that the CRD creation finished but the API is not actually available. The problem is fixed by ignoring the error, waiting for the CRDs to get registered, waiting for the Service monitor resource to be ready and then re-deploying the Prometheus objects again.

Fixes #67 
