### PR TITLE
Add cluster monitoring via kube-state-metrics, etcd metrics and node-exporter

### DIFF
--- a/deploy/deploy-gcs.yml
+++ b/deploy/deploy-gcs.yml
@@ -42,10 +42,14 @@
             - gcs-storage-snapshot.yml
             - gcs-csi-node-info-crd.yml
             - gcs-csi-driver-registry-crd.yml
-            - monitoring-namespace.yml
             - gcs-prometheus-operator.yml
             - gcs-prometheus-bundle.yml
             - gcs-prometheus-alertmanager-cluster.yml
+            - gcs-prometheus-operator-metrics.yml
+            - gcs-prometheus-kube-state-metrics.yml
+            - gcs-prometheus-node-exporter.yml
+            - gcs-prometheus-kube-metrics.yml
+            - gcs-prometheus-etcd.yml
             - gcs-grafana.yml
 
         - name: GCS Pre | Manifests | Create GD2 manifests
@@ -65,11 +69,6 @@
       kube:
         kubectl: "{{ kubectl }}"
         file: "{{ manifests_dir }}/gcs-namespace.yml"
-
-    - name: GCS | Namespace | Create Monitoring namespace
-      kube:
-        kubectl: "{{ kubectl }}"
-        file: "{{ manifests_dir }}/monitoring-namespace.yml"
 
     - name: GCS | ETCD Operator
       block:
@@ -202,7 +201,7 @@
             file: "{{ manifests_dir }}/gcs-prometheus-operator.yml"
 
         - name: GCS | Prometheus Operator | Wait for the Prometheus Operator to become ready
-          command: "{{ kubectl }} -n{{ monitoring_namespace }} -ojsonpath='{.status.availableReplicas}' get deployment prometheus-operator"
+          command: "{{ kubectl }} -n{{ gcs_namespace }} -ojsonpath='{.status.availableReplicas}' get deployment prometheus-operator"
           register: result
           until: result.stdout|int == 1
           delay: 10
@@ -218,23 +217,48 @@
           retries: 30
 
         - name: Check if Service Monitor CRD is registered
-          command: "{{ kubectl }} get servicemonitors -n{{ monitoring_namespace }}"
+          command: "{{ kubectl }} get servicemonitors -n{{ gcs_namespace }}"
           register: result
           until: result.rc == 0
           delay: 10
           retries: 30
 
         - name: Check if Prometheus CRD object is registered
-          command: "{{ kubectl }} get Prometheus -n{{ monitoring_namespace }}"
+          command: "{{ kubectl }} get Prometheus -n{{ gcs_namespace }}"
           register: result
           until: result.rc == 0
           delay: 10
           retries: 30
 
-        - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Objects 
+        - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Objects for Gluster Storage Monitoring
           kube:
             kubectl: "{{ kubectl }}"
             file: "{{ manifests_dir }}/gcs-prometheus-bundle.yml"
+
+        - name: GCS | Kube-State-Metrics Exporter Deployment and corresponding Prometheus Objects
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-kube-state-metrics.yml"
+
+        - name: GCS | Prometheus Objects in order to monitor Kubelet, APIServer and CoreDNS
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-kube-metrics.yml"
+
+        - name: GCS | Prometheus Objects in order to monitor etcd operator and the etcd cluster
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-etcd.yml"
+
+        - name: GCS | Node-Exporter Deployment and corresponding Prometheus Objects
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-node-exporter.yml"
+
+        - name: GCS | Prometheus Objects for monitoring the Prometheus Operator (meta-monitoring)
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-prometheus-operator-metrics.yml"
 
     - name: GCS | Alertmanager Cluster
       kube:

--- a/deploy/templates/gcs-manifests/gcs-grafana.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-grafana.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: data
   labels:
     name: data
-  namespace: monitoring
+  namespace: {{ gcs_namespace }}
 data:
   config: |-
 
@@ -23,7 +23,7 @@ metadata:
   labels:
     app: grafana
   name: grafana
-  namespace: monitoring
+  namespace: {{ gcs_namespace }}
 spec:
   replicas: 1
   selector:
@@ -72,7 +72,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
-  namespace: monitoring
+  namespace: {{ gcs_namespace }}
 spec:
   type: NodePort
   ports:

--- a/deploy/templates/gcs-manifests/gcs-prometheus-alertmanager-cluster.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-alertmanager-cluster.yml.j2
@@ -2,6 +2,16 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: alert
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 spec:
-  replicas: 3
+  replicas: 2
+---
+apiVersion: v1
+data:
+  alertmanager.yaml: Imdsb2JhbCI6IAogICJyZXNvbHZlX3RpbWVvdXQiOiAiNW0iCiJyZWNlaXZlcnMiOiAKLSAibmFtZSI6ICJudWxsIgoicm91dGUiOiAKICAiZ3JvdXBfYnkiOiAKICAtICJqb2IiCiAgImdyb3VwX2ludGVydmFsIjogIjVtIgogICJncm91cF93YWl0IjogIjMwcyIKICAicmVjZWl2ZXIiOiAibnVsbCIKICAicmVwZWF0X2ludGVydmFsIjogIjEyaCIKICAicm91dGVzIjogCiAgLSAibWF0Y2giOiAKICAgICAgImFsZXJ0bmFtZSI6ICJEZWFkTWFuc1N3aXRjaCIKICAgICJyZWNlaXZlciI6ICJudWxsIg==
+kind: Secret
+metadata:
+  name: alertmanager-alert
+  namespace: {{ gcs_namespace }}
+type: Opaque
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-bundle.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-bundle.yml.j2
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: gluster-prometheus
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
   labels:
     team: monitoring
 spec:
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -54,25 +54,23 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 spec:
   replicas: 2
   serviceAccountName: prometheus
   scrapeInterval: 5s
   alerting:
     alertmanagers:
-    - namespace: {{ monitoring_namespace }}
+    - namespace: {{ gcs_namespace }}
       name: alertmanager-alert
       port: metrics
-  serviceMonitorSelector:
-    matchLabels:
-      team: monitoring
+  serviceMonitorSelector: {}
   ruleSelector:
     matchLabels:
       role: alert-rules
@@ -82,7 +80,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 spec:
   type: NodePort
   ports:

--- a/deploy/templates/gcs-manifests/gcs-prometheus-etcd.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-etcd.yml.j2
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: etcd-operator
+  name: etcd-operator
+  namespace: {{ gcs_namespace }}
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+  selector:
+    app.kubernetes.io/component: etcd
+    app.kubernetes.io/name: etcd-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: etcd-operator
+  name: etcd-operator
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - port: metrics
+    path: metrics
+  selector:
+    matchLabels:
+      k8s-app: etcd-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: etcd-metrics
+  name: etcd-metrics
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - port: client
+    path: metrics
+  selector:
+    matchLabels:
+      app: etcd
+      etcd_cluster: etcd
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-kube-metrics.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-kube-metrics.yml.j2
@@ -1,0 +1,81 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: apiserver
+  name: kube-apiserver
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      serverName: kubernetes
+  jobLabel: component
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      component: apiserver
+      provider: kubernetes
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: coredns
+  name: coredns
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 15s
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: coredns
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kubelet
+  name: kubelet
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    path: /metrics/cadvisor
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  selector:
+    matchLabels:
+      k8s-app: kubelet
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-kube-state-metrics.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-kube-state-metrics.yml.j2
@@ -1,0 +1,241 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: {{ gcs_namespace }}
+---
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  labels:
+    app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: {{ gcs_namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app: kube-state-metrics
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=:8443
+        - --upstream=http://127.0.0.1:8081/
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy-main
+        ports:
+        - containerPort: 8443
+          name: https-main
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      - args:
+        - --secure-listen-address=:9443
+        - --upstream=http://127.0.0.1:8082/
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy-self
+        ports:
+        - containerPort: 9443
+          name: https-self
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      - args:
+        - --host=127.0.0.1
+        - --port=8081
+        - --telemetry-host=127.0.0.1
+        - --telemetry-port=8082
+        image: quay.io/coreos/kube-state-metrics:v1.4.0
+        name: kube-state-metrics
+        resources:
+          limits:
+            cpu: 100m
+            memory: 150Mi
+          requests:
+            cpu: 100m
+            memory: 150Mi
+      - command:
+        - /pod_nanny
+        - --container=kube-state-metrics
+        - --cpu=100m
+        - --extra-cpu=2m
+        - --memory=150Mi
+        - --extra-memory=30Mi
+        - --threshold=5
+        - --deployment=kube-state-metrics
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: quay.io/coreos/addon-resizer:1.0
+        name: addon-resizer
+        resources:
+          limits:
+            cpu: 50m
+            memory: 30Mi
+          requests:
+            cpu: 10m
+            memory: 30Mi
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: kube-state-metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: {{ gcs_namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: {{ gcs_namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - name: https-main
+    port: 8443
+    targetPort: https-main
+  - name: https-self
+    port: 9443
+    targetPort: https-self
+  selector:
+    app: kube-state-metrics
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    port: https-main
+    scheme: https
+    scrapeTimeout: 30s
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https-self
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-node-exporter.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-node-exporter.yml.j2
@@ -1,0 +1,159 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-exporter
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-exporter
+subjects:
+- kind: ServiceAccount
+  name: node-exporter
+  namespace: {{ gcs_namespace }}
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-exporter
+  name: node-exporter
+  namespace: {{ gcs_namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        image: quay.io/prometheus/node-exporter:v0.16.0
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --secure-listen-address=$(IP):9100
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: node-exporter
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: {{ gcs_namespace }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: node-exporter
+  name: node-exporter
+  namespace: {{ gcs_namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9100
+    targetPort: https
+  selector:
+    app: node-exporter
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: node-exporter
+  name: node-exporter
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: node-exporter
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-operator-metrics.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-operator-metrics.yml.j2
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: prometheus-operator
+  name: prometheus-operator
+  namespace: {{ gcs_namespace }}
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  selector:
+    k8s-app: prometheus-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: prometheus-operator
+  name: prometheus-operator
+  namespace: {{ gcs_namespace }}
+spec:
+  endpoints:
+  - honorLabels: true
+    port: http
+  selector:
+    matchLabels:
+      k8s-app: prometheus-operator
+

--- a/deploy/templates/gcs-manifests/gcs-prometheus-operator.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-prometheus-operator.yml.j2
@@ -9,7 +9,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -84,7 +84,7 @@ metadata:
   labels:
     k8s-app: prometheus-operator
   name: prometheus-operator
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}
 spec:
   replicas: 1
   selector:
@@ -127,4 +127,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-operator
-  namespace: {{ monitoring_namespace }}
+  namespace: {{ gcs_namespace }}

--- a/deploy/templates/gcs-manifests/monitoring-namespace.yml.j2
+++ b/deploy/templates/gcs-manifests/monitoring-namespace.yml.j2
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ monitoring_namespace }}


### PR DESCRIPTION
This PR proposes the following additions/changes:
1) Deploy kube-state-metrics exporter and corresponding service to expose it and added prometheus serviceMonitor
2) Deploy node-exporter and corresponding prometheus service to expose it and added prometheus  serviceMonitor.
3) Pick up metrics exposed by Kubelet, CoreDNS and APIServer.
4) Pick up metrics exposed by the Prometheus Operator itself.
5) Removed the monitoring namespace and integrated the whole monitoring stack in the gcs namespace itself,
6) Mounted an arbitrary dummy secret that is used by the alertmanager. Otherwise the alertmanager would be in containerCreating state( only becomes ready when the secret is mounted).
Fixes #88 
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>