### PR TITLE
Add deployment of Anthill to GCS

### DIFF
--- a/deploy/deploy-gcs.yml
+++ b/deploy/deploy-gcs.yml
@@ -47,6 +47,8 @@
             - gcs-prometheus-bundle.yml
             - gcs-prometheus-alertmanager-cluster.yml
             - gcs-grafana.yml
+            - gcs-operator-crd.yml
+            - gcs-operator.yml
 
         - name: GCS Pre | Manifests | Create GD2 manifests
           include_tasks: tasks/create-gd2-manifests.yml
@@ -84,6 +86,34 @@
           until: result.stdout|int == 1
           delay: 10
           retries: 50
+
+    - name: GCS | Anthill
+      block:
+        - name: GCS | Anthill | Register CRDs
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-operator-crd.yml"
+
+        - name: Wait for GlusterCluster CRD to be registered
+          command: "{{ kubectl }} get customresourcedefinitions glusterclusters.operator.gluster.org"
+          changed_when: false
+          register: result
+          until: result.rc == 0
+          delay: 10
+          retries: 30
+
+        - name: Wait for GlusterNode CRD to be registered
+          command: "{{ kubectl }} get customresourcedefinitions glusternodes.operator.gluster.org"
+          changed_when: false
+          register: result
+          until: result.rc == 0
+          delay: 10
+          retries: 30
+
+        - name: GCS | Anthill | Deploy operator
+          kube:
+            kubectl: "{{ kubectl }}"
+            file: "{{ manifests_dir }}/gcs-operator.yml"
 
     - name: GCS | ETCD Cluster
       block:
@@ -188,7 +218,7 @@
           until: result.stdout|int == groups['kube-node']|length
           delay: 10
           retries: 50
-          
+
     - name: GCS | Storage | Snapshot | Create Storage and Snapshot class
       kube:
           kubectl: "{{ kubectl }}"
@@ -208,7 +238,7 @@
           delay: 10
           retries: 50
 
-    - name: GCS | Prometheus Objects 
+    - name: GCS | Prometheus Objects
       block:
         - name: Check if the Custrom Resource Definitions are set
           command: "{{ kubectl }} get customresourcedefinitions servicemonitors.monitoring.coreos.com"
@@ -231,7 +261,7 @@
           delay: 10
           retries: 30
 
-        - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Objects 
+        - name: GCS | Prometheus Objects | Deploy services, ServiceMonitor and Prometheus Objects
           kube:
             kubectl: "{{ kubectl }}"
             file: "{{ manifests_dir }}/gcs-prometheus-bundle.yml"

--- a/deploy/templates/gcs-manifests/gcs-operator-crd.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-operator-crd.yml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: glusterclusters.operator.gluster.org
+spec:
+  group: operator.gluster.org
+  names:
+    kind: GlusterCluster
+    listKind: GlusterClusterList
+    plural: glusterclusters
+    singular: glustercluster
+  scope: Namespaced
+  version: v1alpha1
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: glusternodes.operator.gluster.org
+spec:
+  group: operator.gluster.org
+  names:
+    kind: GlusterNode
+    listKind: GlusterNodeList
+    plural: glusternodes
+    singular: glusternode
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/templates/gcs-manifests/gcs-operator.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-operator.yml.j2
@@ -1,0 +1,95 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: anthill
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - servicemonitors
+    verbs: ["get", "create"]
+  - apiGroups: ["operator.gluster.org"]
+    resources:
+      - glusterclusters
+      - glusternodes
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: anthill
+  namespace: {{ gcs_namespace }}
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: anthill
+subjects:
+  - kind: ServiceAccount
+    name: anthill
+    namespace: {{ gcs_namespace }}
+roleRef:
+  kind: Role
+  name: anthill
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: anthill
+  namespace: {{ gcs_namespace }}
+  labels:
+    app.kubernetes.io/part-of: gcs
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: anthill
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: anthill
+  template:
+    metadata:
+      labels:
+        name: anthill
+    spec:
+      serviceAccountName: anthill
+      containers:
+        - name: anthill
+          image: quay.io/gluster/anthill:latest
+          ports:
+            - containerPort: 60000
+              name: metrics
+          command:
+            - anthill
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "anthill"


### PR DESCRIPTION
This will deploy the latest version of the operator along with the rest of GCS. Currently, the operator doesn't do anything useful. As it handles more of the deployment, we can trim down the rest of the `deploy-gcs.yml` playbook.

Fixes #87 