### PR TITLE
Add anthill role to correct (gcs) namespace

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-operator.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-operator.yml.j2
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: anthill
+  namespace: {{ gcs_namespace }}
 rules:
   - apiGroups: [""]
     resources:
@@ -43,6 +44,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: anthill
+  namespace: {{ gcs_namespace }}
 subjects:
   - kind: ServiceAccount
     name: anthill


### PR DESCRIPTION
The Role & RoleBinding were being created in the "default" namespace
instead of the "gcs" namespace. The result was that Anthill was unable
to query the running pods due to insufficient permissions of its service
account. As a result, the Anthill pod was in CrashLoop. This adds the
proper namespace tags to put the Role/RoleBinding into the gcs namespace
giving the operator's service account appropriate permissions.