### PR TITLE
Add timeout option in gluster-csi-driver

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-csi.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-csi.yml.j2
@@ -92,6 +92,7 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--resturl=$(REST_URL)"
+            - "--resttimeout=120" #glusterd2 client timeout in sec
           env:
             - name: NODE_ID
               valueFrom:
@@ -203,6 +204,7 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--resturl=$(REST_URL)"
+            - "--resttimeout=120" #glusterd2 client timeout in sec
           env:
             - name: NODE_ID
               valueFrom:
@@ -351,6 +353,7 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--resturl=$(REST_URL)"
+            - "--resttimeout=120" #glusterd2 client timeout in sec
           env:
             - name: NODE_ID
               valueFrom:


### PR DESCRIPTION
Default timeout in rest client is 30s, having 30 sec
of timeout is not enough to communicate
with glusterd2, so providing a new configuration
to set the rest client timeout.

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

Merge this ones https://github.com/gluster/gluster-csi-driver/pull/137 is merged