### PR TITLE
Install socat in vagrant-playbook.yml

### DIFF
--- a/deploy/deploy-k8s.yml
+++ b/deploy/deploy-k8s.yml
@@ -1,24 +1,7 @@
+# This playbook should only contain general customization required to deploy a
+# K8S cluster ready to run GCS. Any specific customizations with respect to the
+# vagrant environment needs to be done in vagrant-playbook.
 ---
-- name: Install extra packages
-  hosts: all
-  become: true
-  tasks:
-
-  - name: Install packages
-    command: "rpm-ostree install {{ item }}"
-    with_items:
-      # socat is needed for Helm
-      - socat
-
-  - name: Reboot to make layered packages available
-    shell: sleep 2 && systemctl reboot
-    async: 1
-    poll: 0
-
-  - name: Wait for host to be available
-    wait_for_connection:
-      delay: 15
-
 - name: Deploy K8S
   import_playbook: "kubespray/cluster.yml"
   vars:

--- a/deploy/vagrant-playbook.yml
+++ b/deploy/vagrant-playbook.yml
@@ -1,4 +1,6 @@
 ---
+# Any specific customization required in the vagrant environment needs to be
+# done in this play
 - name: Pre-deploy bootstrapping
   hosts: all
   become: true
@@ -38,7 +40,24 @@
         content: "{{ item }}"
       with_items: "{{ kmods }}"
 
+    - name: Install packages
+      command: "rpm-ostree install {{ item }}"
+      with_items:
+        # socat is needed for Helm
+        - socat
+
+    - name: Reboot to make layered packages available
+      shell: sleep 2 && systemctl reboot
+      async: 1
+      poll: 0
+
+    - name: Wait for host to be available
+      wait_for_connection:
+        delay: 15
+
+
 - import_playbook: "./deploy-k8s.yml"
   vars:
+    # local_release_dir needs to be set for atomic hosts.
     local_release_dir: "/var/vagrant/temp"
 - import_playbook: "./deploy-gcs.yml"


### PR DESCRIPTION
... instead of in deploy-k8s.yml, allowing it to be used outside the
vagrant environment. Any specific customization needed in the vagrant
environment needs to be done in vagrant-playbook.yml.