### PR TITLE
Switch gluster CSI driver container image

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-csi.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-csi.yml.j2
@@ -86,7 +86,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: glusterfs
-          image: docker.io/gluster/gluster-csi-driver:latest
+          image: docker.io/gluster/glusterfs-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--v=5"
@@ -196,7 +196,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: docker.io/gluster/gluster-csi-driver:latest
+          image: docker.io/gluster/glusterfs-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--v=5"
@@ -361,7 +361,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
 
         - name: gluster-provisioner
-          image: docker.io/gluster/gluster-csi-driver:latest
+          image: docker.io/gluster/glusterfs-csi-driver:latest
           args:
             - "--nodeid=$(NODE_ID)"
             - "--v=5"


### PR DESCRIPTION
The gluster file-based CSI driver is now built as `gluster/glusterfs-csi-driver` in Quay and Docker Hub. This commit moves from the now deprecated gluster-csi-driver to the new name.

Requires gluster/gluster-csi-driver#159