### PR TITLE
Make /dev available to glustervirtblock-nodeplugin

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-virtblock-csi.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-virtblock-csi.yml.j2
@@ -144,12 +144,17 @@ spec:
             - name: REST_URL
               value: http://glusterd2-client.{{ gcs_namespace }}:24007
           volumeMounts:
+            - name: gluster-dev
+              mountPath: /dev
             - name: plugin-dir
               mountPath: /plugin
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
       volumes:
+        - name: gluster-dev
+          hostPath:
+            path: /dev
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/org.gluster.glustervirtblock


### PR DESCRIPTION
glustervirtblock-nodeplugin mounts the virtual block
which has to create devices at /dev. Without /dev
bind mounted, device creation fails.

Signed-off-by: Kotresh HR <khiremat@redhat.com>