### PR TITLE
Changed `glustercsctl` tool as kubectl plugin

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,8 +4,8 @@ layout: doc
 order: 2
 ---
 
-Install `glustercsctl` tool in one of the Kubernetes Master nodes
-using `pip3 install glustercsctl`.
+Install kubectl Gluster plugin in one of the Kubernetes Master nodes
+using `pip3 install kubectl-gluster`.
 
 Prepare the configuration file as required to deploy GlusterCS.
 
@@ -44,8 +44,10 @@ Run the following command to deploy the GlusterCS cluster on an already
 running kubernetes cluster.
 
 ```
-glustercsctl deploy mycluster.yaml
+kubectl gluster deploy mycluster.yaml
 ```
+
+**Note**: Run `kubectl-gluster` if kubectl version is less than `v1.13`
 
 To test whether the deployment was successfull or not, you can run
 `kubectl get pods -n <namespace>` command on the master node. For

--- a/doc/quick-start-guide.md
+++ b/doc/quick-start-guide.md
@@ -9,8 +9,8 @@ storage management experience with a leaner Gluster stack underneath
 with focus on helping users to stay away from their storage related
 worries especially when working on a hybrid cloud environment.
 
-Install `glustercsctl` tool in one of the Kubernetes Master nodes
-using `pip3 install glustercsctl`.
+Install kubectl Gluster plugin in one of the Kubernetes Master nodes
+using `pip3 install kubectl-gluster`.
 
 Prepare the configuration file as required to deploy GlusterCS.
 
@@ -49,8 +49,10 @@ Run the following command to deploy the GlusterCS cluster on an already
 running kubernetes cluster.
 
 ```
-glustercsctl deploy mycluster.yaml
+kubectl gluster deploy mycluster.yaml
 ```
+
+**Note**: Run `kubectl-gluster` if kubectl version is less than `v1.13`
 
 To test whether the deployment was successfull or not, you can run
 `kubectl get pods -n <namespace>` command on the master node. For

--- a/pages/005-ease-of-use.md
+++ b/pages/005-ease-of-use.md
@@ -18,7 +18,7 @@ nodes:
 ```
 
 ```
-glustercsctl deploy ./mycluster.yml
+kubectl gluster deploy ./mycluster.yml
 ```
 
 Easy to install on an already running kubernetes cluster.


### PR DESCRIPTION
kubectl plugins are supported from `v1.13`
https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/

Converted `glustercsctl` tool into kubectl plugin. Updated the doc pages
for the same.

Signed-off-by: Aravinda VK <avishwan@redhat.com>