### PR TITLE
Include Rsyslog sidecar container in the gd2 stateful set

### DIFF
--- a/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
+++ b/deploy/templates/gcs-manifests/gcs-gd2.yml.j2
@@ -73,6 +73,11 @@ spec:
               mountPath: "/var/lib/glusterd2"
             - name: glusterd2-logdir
               mountPath: "/var/log/glusterd2"
+        - name: rsyslog-sidecar
+          image: docker.io/gluster/gluster-rsyslog
+          volumeMounts:
+            - name: glusterd2-logdir
+              mountPath: "/var/log/glusterd2"
       volumes:
         - name: gluster-dev
           hostPath:


### PR DESCRIPTION
DO NOT MERGE

Included gluster-rsyslog sidecar container deployed along with the glusterd2 containers. The ryslog containers take the glusterd2 logs(for now only glusterd2 logs, parsing the other logs are under progress) as input,parses it and push it into stdout in standard rsyslog debug format. The PR for the gluster-rsyslog container Dockerfile and rsyslog conf files is :  https://github.com/gluster/gluster-containers/pull/138.
